### PR TITLE
Feat. er직원 전문분야 및 진료과 추가 및 관련 api, department 관련 api

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@nestjs/platform-express": "^10.2.5",
     "@nestjs/schedule": "^3.0.4",
     "@nestjs/swagger": "^7.1.12",
-    "@prisma/client": "5.4.1",
+    "@prisma/client": "5.5.2",
     "add": "^2.0.6",
     "bcrypt": "^5.1.1",
     "cache-manager": "^5.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ dependencies:
     specifier: ^7.1.12
     version: 7.1.12(@nestjs/common@10.2.5)(@nestjs/core@10.2.5)(reflect-metadata@0.1.13)
   '@prisma/client':
-    specifier: 5.4.1
-    version: 5.4.1(prisma@5.4.1)
+    specifier: 5.5.2
+    version: 5.5.2(prisma@5.4.1)
   add:
     specifier: ^2.0.6
     version: 2.0.6
@@ -1722,8 +1722,8 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@prisma/client@5.4.1(prisma@5.4.1):
-    resolution: {integrity: sha512-xyD0DJ3gRNfLbPsC+YfMBBuLJtZKQfy1OD2qU/PZg+HKrr7SO+09174LMeTlWP0YF2wca9LxtVd4HnAiB5ketQ==}
+  /@prisma/client@5.5.2(prisma@5.4.1):
+    resolution: {integrity: sha512-54XkqR8M+fxbzYqe+bIXimYnkkcGqgOh0dn0yWtIk6CQT4IUCAvNFNcQZwk2KqaLU+/1PHTSWrcHtx4XjluR5w==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -1732,12 +1732,12 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.4.1-1.2f302df92bd8945e20ad4595a73def5b96afa54f
+      '@prisma/engines-version': 5.5.1-1.aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a
       prisma: 5.4.1
     dev: false
 
-  /@prisma/engines-version@5.4.1-1.2f302df92bd8945e20ad4595a73def5b96afa54f:
-    resolution: {integrity: sha512-+nUQM/y8C+1GG5Ioeqcu6itFslCfxvQSAUVSMC9XM2G2Fcq0F4Afnp6m0pXF6X6iUBWen7jZBPmM9Qlq4Nr3/A==}
+  /@prisma/engines-version@5.5.1-1.aebc046ce8b88ebbcb45efe31cbe7d06fd6abc0a:
+    resolution: {integrity: sha512-O+qHFnZvAyOFk1tUco2/VdiqS0ym42a3+6CYLScllmnpbyiTplgyLt2rK/B9BTjYkSHjrgMhkG47S0oqzdIckA==}
     dev: false
 
   /@prisma/engines@5.4.1:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model er_Hospital {
 
   ///
   /// default 
-  created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -48,16 +48,87 @@ model er_Employee {
   password      String          @db.VarChar(255)
   role          er_EmployeeRole
 
+  department_id Int?
   /// default 
-  created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at     DateTime @default(now()) @db.Timestamptz /// @format date-time
+  updated_at     DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
+  status         Status   @default(ACTIVE)
+
+  /// relation
+  hospital                       er_Hospital                       @relation(fields: [hospital_id], references: [hospital_id])
+  department                     er_Department?                    @relation(fields: [department_id], references: [department_id])
+  employee_doctor_specializations er_EmployeeDoctorSpecialization[]
+  employee_nurse_specializations  er_EmployeeNurseSpecialization[]
+
+  @@unique([id_card, hospital_id])
+  @@map("employee")
+  @@schema("er")
+}
+
+model er_EmployeeDoctorSpecialization {
+  employee_id              String @db.VarChar(50)
+  doctor_specialization_id String @db.VarChar(50)
+
+  /// default
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
+  status     Status   @default(ACTIVE)
+
+  /// relation
+  employee              er_Employee             @relation(fields: [employee_id], references: [employee_id])
+  doctor_specialization er_DoctorSpecialization @relation(fields: [doctor_specialization_id], references: [doctor_specialization_id])
+
+  @@id([employee_id, doctor_specialization_id])
+  @@map("employee_doctor_specialization")
+  @@schema("er")
+}
+
+model er_EmployeeNurseSpecialization {
+  employee_id             String @db.VarChar(50)
+  nurse_specialization_id String @db.VarChar(50)
+
+  /// default
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
+  status     Status   @default(ACTIVE)
+
+  /// relation
+  employee             er_Employee            @relation(fields: [employee_id], references: [employee_id])
+  nurse_specialization er_NurseSpecialization @relation(fields: [nurse_specialization_id], references: [nurse_specialization_id])
+
+  @@id([employee_id, nurse_specialization_id])
+  @@map("employee_nurse_specialization")
+  @@schema("er")
+}
+
+model er_DoctorSpecialization {
+  doctor_specialization_id   String @id @default(uuid())
+  doctor_specialization_name String @db.VarChar(50)
+
+  department_id Int
+
+  /// default
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
   /// relation
-  hospital er_Hospital @relation(fields: [hospital_id], references: [hospital_id])
+  department                      er_Department                     @relation(fields: [department_id], references: [department_id])
+  employee_doctor_specializations er_EmployeeDoctorSpecialization[]
 
-  @@unique([id_card, hospital_id])
-  @@map("employee")
+  @@map("doctor_specialization")
+  @@schema("er")
+}
+
+model er_NurseSpecialization {
+  nurse_specialization_id   String @id @default(uuid())
+  nurse_specialization_name String @db.VarChar(50)
+
+  /// default
+  created_at                     DateTime                         @default(now()) @db.Timestamptz /// @format date-time
+  updated_at                     DateTime                         @default(now()) @updatedAt @db.Timestamptz /// @format date-time
+  status                         Status                           @default(ACTIVE)
+  employee_nurse_specializations er_EmployeeNurseSpecialization[]
+
+  @@map("nurse_specialization")
   @@schema("er")
 }
 
@@ -67,15 +138,16 @@ model er_Department {
   parent_department_id Int?
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
   /// relation
-  parent_department    er_Department?          @relation("DepartmentToSubDepartment", fields: [parent_department_id], references: [department_id])
-  sub_departments      er_Department[]         @relation("DepartmentToSubDepartment")
-  hospital_departments er_HospitalDepartment[]
-
+  parent_department     er_Department?            @relation("DepartmentToSubDepartment", fields: [parent_department_id], references: [department_id])
+  sub_departments       er_Department[]           @relation("DepartmentToSubDepartment")
+  hospital_departments  er_HospitalDepartment[]
+  doctor_specializations er_DoctorSpecialization[]
+  employee              er_Employee[]
   @@map("department")
   @@schema("er")
 }
@@ -85,7 +157,7 @@ model er_HospitalDepartment {
   department_id Int
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -111,7 +183,7 @@ model er_EmergencyCenter {
   emergency_center_longitude       Float
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -130,7 +202,7 @@ model er_EmergencyRoom {
   emergency_room_name String               @db.VarChar(50)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -148,7 +220,7 @@ model er_EmergencyRoomBed {
   emergency_room_bed_status er_EmergencyRoomBedStatus @default(AVAILABLE)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -169,7 +241,7 @@ model er_EmergencyRoomBedLog {
   patient_id                String
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -192,7 +264,7 @@ model er_Patient {
   patient_address         String @db.VarChar(50)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -211,7 +283,7 @@ model er_PatientLog {
   log_desc   String   @db.VarChar(255)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -228,7 +300,7 @@ model er_ServereIllness {
   servere_illness_name String @db.VarChar(50)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -244,7 +316,7 @@ model er_HospitalServereIllness {
   servere_illness_id String @db.VarChar(50)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -262,7 +334,7 @@ model er_MedicalEquipment {
   medical_equipment_name String @db.VarChar(50)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -279,7 +351,7 @@ model er_HospitalMedicalEquipment {
   medical_equipment_count Int
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -292,16 +364,15 @@ model er_HospitalMedicalEquipment {
   @@schema("er")
 }
 
-
 model er_Response {
   emergency_center_id String @db.VarChar(50)
   request_id          String @db.VarChar(50)
-  
-  response er_ResponseType 
-  reject_reason String? @db.VarChar(255)
+
+  response      er_ResponseType
+  reject_reason String?         @db.VarChar(255)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -310,11 +381,12 @@ model er_Response {
   @@schema("er")
 }
 
-
 enum er_EmployeeRole {
   ADMIN
-  DOCTOR
+  SPECIALIST
+  RESIDENT
   NURSE
+  EMT
   RECEPTIONIST
 
   @@schema("er")
@@ -370,10 +442,10 @@ enum er_MedicalInstitutionType {
   @@schema("er")
 }
 
-
 enum er_ResponseType {
   ACCEPTED
   REJECTED
+
   @@schema("er")
 }
 
@@ -389,7 +461,7 @@ model ems_AmbulanceCompany {
   ambulance_company_phone          String  @db.VarChar(20)
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -408,7 +480,7 @@ model ems_Ambulance {
   ambulance_number     String            @db.VarChar(50)
 
   /// default
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -428,7 +500,7 @@ model ems_Employee {
   password             String           @db.VarChar(255)
 
   /// default
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -456,11 +528,11 @@ model ems_Patient {
   guardian_id             String?           @unique @db.VarChar(50)
   ems_employee_id         String            @db.VarChar(50)
   complete_date           DateTime?         @default("1970-01-01T00:00:00Z") @db.Timestamptz /// @format date-time/// 유닉스 타임스탬프 "1970-01-01T00:00:00Z" = 아직 완료 안함
-  patient_status ems_PatientStatus @default(PENDING) /// 대기중 // 요청전 단계
+  patient_status          ems_PatientStatus @default(PENDING) /// 대기중 // 요청전 단계
   /// default 
-  created_at     DateTime          @default(now()) @db.Timestamptz /// @format date-time
-  updated_at     DateTime          @default(now()) @updatedAt @db.Timestamptz /// @format date-time
-  status         Status            @default(ACTIVE)
+  created_at              DateTime          @default(now()) @db.Timestamptz /// @format date-time
+  updated_at              DateTime          @default(now()) @updatedAt @db.Timestamptz /// @format date-time
+  status                  Status            @default(ACTIVE)
 
   /// relation
   guardian     ems_Guardian?
@@ -481,12 +553,13 @@ model ems_PatientSalt {
   salt       String @db.VarChar(255)
 
   /// default
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
   /// relation
-  patient ems_Patient             @relation(fields: [patient_id], references: [patient_id])
+  patient ems_Patient @relation(fields: [patient_id], references: [patient_id])
+
   @@map("patient_salt")
   @@schema("ems")
 }
@@ -499,7 +572,7 @@ model ems_Guardian {
   guardian_relation ems_GuardianRelation /// 환자와의 관계
 
   /// default 
-    created_at DateTime @default(now())   @db.Timestamptz /// @format date-time
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
   updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status     Status   @default(ACTIVE)
 
@@ -522,7 +595,7 @@ model ems_ABCDE_Assessment {
   exposure_notes                       String               @db.VarChar(255) /// 노출 상태 : 외상, 화상, 발진, 저체온, 기타노출에 대한 상세 내용
   /// default
   created_at                           DateTime             @default(now()) @db.Timestamptz /// @format date-time
-  updated_at                           DateTime             @default(now()) @updatedAt  @db.Timestamptz /// @format date-time
+  updated_at                           DateTime             @default(now()) @updatedAt @db.Timestamptz /// @format date-time
   status                               Status               @default(ACTIVE)
 
   /// relation
@@ -624,7 +697,6 @@ model ems_OPQRST_Assessment {
   @@map("opqrst_assessment")
   @@schema("ems")
 }
-
 
 enum ems_EmployeeRole {
   ADMIN
@@ -731,7 +803,7 @@ enum RequestStatus {
   REJECTED /// 거절됨
   CANCELED /// 취소됨
   COMPLETED /// 완료됨
-  
+
   @@schema("request")
 }
 
@@ -760,65 +832,60 @@ enum Status {
   @@schema("public")
 }
 
-
-
 /// ////
 /// request schema
 /// ////
 
 model req_EmsToErRequest {
-  patient_id     String            @db.VarChar(50)
-  emergency_center_id String      @db.VarChar(50)
-  request_status RequestStatus @default(REQUESTED)
-  request_date   DateTime          @default(now()) @db.Timestamptz /// @format date-time
-  reject_reason  String?           @db.VarChar(255)
-  response_date        DateTime    @default("1970-01-01T00:00:00Z") @db.Timestamptz /// @format date-time /// 유닉스 타임스탬프 "1970-01-01T00:00:00Z" = 아직 응답 안함
-  
-  emergency_center_name       String      @db.VarChar(50)
-  emergency_center_latitude   Float
-  emergency_center_longitude  Float
-  distance            Float       @default(0) /// 응급차와 응급실 사이의 거리
+  patient_id          String        @db.VarChar(50)
+  emergency_center_id String        @db.VarChar(50)
+  request_status      RequestStatus @default(REQUESTED)
+  request_date        DateTime      @default(now()) @db.Timestamptz /// @format date-time
+  reject_reason       String?       @db.VarChar(255)
+  response_date       DateTime      @default("1970-01-01T00:00:00Z") @db.Timestamptz /// @format date-time /// 유닉스 타임스탬프 "1970-01-01T00:00:00Z" = 아직 응답 안함
 
-
+  emergency_center_name      String @db.VarChar(50)
+  emergency_center_latitude  Float
+  emergency_center_longitude Float
+  distance                   Float  @default(0) /// 응급차와 응급실 사이의 거리
 
   /// default
-  created_at         DateTime     @default(now()) @db.Timestamptz /// @format date-time
-  updated_at         DateTime     @default(now()) @updatedAt @db.Timestamptz /// @format date-time
-  status             Status       @default(ACTIVE)
+  created_at DateTime    @default(now()) @db.Timestamptz /// @format date-time
+  updated_at DateTime    @default(now()) @updatedAt @db.Timestamptz /// @format date-time
+  status     Status      @default(ACTIVE)
   /// relation
-  patient            req_Patient  @relation(fields: [patient_id], references: [patient_id])
+  patient    req_Patient @relation(fields: [patient_id], references: [patient_id])
+
   @@id([patient_id, emergency_center_id])
   @@map("ems_to_er_request")
   @@schema("request")
 }
 
 model req_Patient {
-  patient_id     String           @id @db.VarChar(50)
-  patient_name   String           @default("익명") @db.VarChar(50) /// 익명으로 기본값
-  patient_birth  String           @default("0000-00-00") @db.VarChar(50) /// 생년월일 0000-00-00 형식 0000-00-00은 미상
-  patient_gender Gender
-  patient_severity       ems_Severity /// 중증, 경증, 정상, 미상
+  patient_id       String       @id @db.VarChar(50)
+  patient_name     String       @default("익명") @db.VarChar(50) /// 익명으로 기본값
+  patient_birth    String       @default("0000-00-00") @db.VarChar(50) /// 생년월일 0000-00-00 형식 0000-00-00은 미상
+  patient_gender   Gender
+  patient_severity ems_Severity /// 중증, 경증, 정상, 미상
 
-  patient_symptom_summary String            @db.VarChar(255)
+  patient_symptom_summary String @db.VarChar(255)
   patient_latitude        Float /// 위도 - 사고지점
   patient_longitude       Float /// 경도 - 사고지점
 
   /// 요청한 곳
-  ambulance_company_id String           @db.VarChar(50)
-  ambulance_company_name String         @db.VarChar(50)
-  ems_employee_id String          @db.VarChar(50)
-  ems_employee_name String        @db.VarChar(50)
+  ambulance_company_id   String @db.VarChar(50)
+  ambulance_company_name String @db.VarChar(50)
+  ems_employee_id        String @db.VarChar(50)
+  ems_employee_name      String @db.VarChar(50)
 
   /// default
-  created_at     DateTime         @default(now()) @db.Timestamptz /// @format date-time
-  updated_at     DateTime         @default(now()) @updatedAt @db.Timestamptz /// @format date-time
-  status         Status           @default(ACTIVE)
+  created_at DateTime @default(now()) @db.Timestamptz /// @format date-time
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz /// @format date-time
+  status     Status   @default(ACTIVE)
 
   /// relation
   ems_to_er_request req_EmsToErRequest[]
+
   @@map("patient")
   @@schema("request")
 }
-
-
-

--- a/src/common/database/db.init.ts
+++ b/src/common/database/db.init.ts
@@ -5,10 +5,12 @@ import {
   ems_AmbulanceCompany,
   ems_EmployeeRole,
   er_Department,
+  er_DoctorSpecialization,
   er_EmergencyCenter,
   er_EmployeeRole,
   er_Hospital,
   er_MedicalEquipment,
+  er_NurseSpecialization,
 } from '@prisma/client';
 import bcrypt from 'bcrypt';
 import fs from 'fs';
@@ -27,6 +29,8 @@ export class DbInit {
     await this.hospitalSetup();
     await this.emergencyCenterSetup();
     await this.departmentSetup();
+    await this.doctorSpecializationSetup();
+    await this.nurseSpecializationSetup();
     await this.medicalEquipmentSetup();
     await this.servereIllnessSetup();
     await this.emergencyRoomSetup();
@@ -49,10 +53,14 @@ export class DbInit {
       this.prismaService.er_HospitalDepartment.deleteMany({ where: {} }),
       this.prismaService.er_HospitalMedicalEquipment.deleteMany({ where: {} }),
       this.prismaService.er_HospitalServereIllness.deleteMany({ where: {} }),
+      this.prismaService.er_EmployeeDoctorSpecialization.deleteMany({ where: {} }),
+      this.prismaService.er_EmployeeNurseSpecialization.deleteMany({ where: {} }),
       this.prismaService.er_Employee.deleteMany({ where: {} }),
       this.prismaService.er_Hospital.deleteMany({ where: {} }),
       this.prismaService.er_MedicalEquipment.deleteMany({ where: {} }),
       this.prismaService.er_Department.deleteMany({ where: {} }),
+      this.prismaService.er_DoctorSpecialization.deleteMany({ where: {} }),
+      this.prismaService.er_NurseSpecialization.deleteMany({ where: {} }),
       this.prismaService.ems_DCAP_BTLS_Assessment.deleteMany({ where: {} }),
       this.prismaService.ems_ABCDE_Assessment.deleteMany({ where: {} }),
       this.prismaService.ems_SAMPLE_Assessment.deleteMany({ where: {} }),
@@ -212,6 +220,25 @@ export class DbInit {
 
     await this.prismaService.ems_Employee.createMany({
       data: employees,
+      skipDuplicates: true,
+    });
+  }
+
+  async doctorSpecializationSetup() {
+    this.logger.debug('doctorSpecializationSetup');
+    const file_path = path.join(__dirname, '../../../src/common/database/doctor_specializations.db.json');
+    const json: er_DoctorSpecialization[] = JSON.parse(fs.readFileSync(file_path, 'utf-8'));
+    await this.prismaService.er_DoctorSpecialization.createMany({
+      data: json,
+      skipDuplicates: true,
+    });
+  }
+  async nurseSpecializationSetup() {
+    this.logger.debug('nurseSpecializationSetup');
+    const file_path = path.join(__dirname, '../../../src/common/database/nurse_specializations.db.json');
+    const json: er_NurseSpecialization[] = JSON.parse(fs.readFileSync(file_path, 'utf-8'));
+    await this.prismaService.er_NurseSpecialization.createMany({
+      data: json,
       skipDuplicates: true,
     });
   }

--- a/src/common/util/excludeKeys.ts
+++ b/src/common/util/excludeKeys.ts
@@ -1,0 +1,7 @@
+export const excludeKeys = <T>(obj: T, keys: (keyof T)[]) => {
+  const result = { ...obj };
+  keys.forEach((key) => {
+    delete result[key];
+  });
+  return result;
+};

--- a/src/config/errors/er.error.ts
+++ b/src/config/errors/er.error.ts
@@ -2,6 +2,9 @@ import { HttpStatus } from '@nestjs/common';
 import typia from 'typia';
 import { ERROR } from '.';
 
+export namespace ER_ERROR {
+  export interface ER_NOT_FOUND extends ERROR<"ER doesn't exist", HttpStatus.NOT_FOUND> {}
+}
 export namespace ER_EMPLOYEE_ERROR {
   export interface EMPLOYEE_MULTIPLE_ALREADY_EXIST
     extends ERROR<'EMPLOYEE_MULTIPLE_ALREADY_EXIST', HttpStatus.BAD_REQUEST> {}
@@ -16,6 +19,8 @@ export namespace ER_EMPLOYEE_ERROR {
 export namespace ER_DEPARTMENT_ERROR {
   export interface DEPARTMENT_NOT_EXIST extends ERROR<"Department doesn't exist: ", HttpStatus.BAD_REQUEST> {}
   export const departmentNotExist = typia.random<DEPARTMENT_NOT_EXIST>();
+
+  export interface DEPARTMENT_INVALID extends ERROR<'Department is invalid', HttpStatus.BAD_REQUEST> {}
 }
 
 export namespace ER_EMERGENCY_CENTER_ERROR {

--- a/src/config/errors/er.error.ts
+++ b/src/config/errors/er.error.ts
@@ -9,6 +9,8 @@ export namespace ER_EMPLOYEE_ERROR {
   export interface EMPLOYEE_NOT_FOUND extends ERROR<"Employee doesn't exist", HttpStatus.BAD_REQUEST> {}
   export interface EMPLOYEE_PASSWORD_INVALID extends ERROR<'Password is invalid', HttpStatus.BAD_REQUEST> {}
   export interface EMPLOYEE_PASSWORD_SAME extends ERROR<'Password is same', HttpStatus.BAD_REQUEST> {}
+  export interface EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH
+    extends ERROR<'Role and specialization not match', HttpStatus.BAD_REQUEST> {}
 }
 
 export namespace ER_DEPARTMENT_ERROR {

--- a/src/controllers/ems/ems.ambulance.controller.ts
+++ b/src/controllers/ems/ems.ambulance.controller.ts
@@ -6,7 +6,7 @@ import { EmsAmbulanceService } from '@src/providers/ems/ems.ambulance.service';
 import { TryCatch } from '@src/types';
 import { EmsAmbulanceResponse } from '@src/types/ems.response.dto';
 
-@Controller('/ems/ambulance')
+@Controller('/ems/ambulances')
 export class EmsAmbulanceController {
   constructor(private readonly emsAmbulanceService: EmsAmbulanceService) {}
   /**

--- a/src/controllers/ems/ems.ambulanceCompany.controller.ts
+++ b/src/controllers/ems/ems.ambulanceCompany.controller.ts
@@ -7,7 +7,7 @@ import { Try, TryCatch } from '@src/types';
 import { EmsAmbulanceCompanyRequest } from '@src/types/ems.request.dto';
 import { EmsAmbulanceCompanyResponse } from '@src/types/ems.response.dto';
 
-@Controller('/ems/ambulance-company')
+@Controller('/ems/ambulance-companies')
 export class EmsAmbulanceCompanyController {
   constructor(private readonly emsAmbulanceCampanyService: EmsAmbulanceCampanyService) {}
 

--- a/src/controllers/ems/ems.employee.controller.ts
+++ b/src/controllers/ems/ems.employee.controller.ts
@@ -12,7 +12,7 @@ import { EmsEmployeeRequest } from '@src/types/ems.request.dto';
 import { EmsEmployeeResponse } from '@src/types/ems.response.dto';
 import { assertPrune } from 'typia/lib/misc';
 
-@Controller('/ems/employee')
+@Controller('/ems/employees')
 export class EmsEmployeeController {
   constructor(private readonly emsEmployeeService: EmsEmployeeService) {}
 

--- a/src/controllers/ems/ems.patient.controller.ts
+++ b/src/controllers/ems/ems.patient.controller.ts
@@ -16,7 +16,7 @@ import { EmsPatientService } from '@src/providers/ems/ems.patient.service';
 import { Try, TryCatch } from '@src/types';
 import { EmsPatientRequest } from '@src/types/ems.request.dto';
 import { EmsPatientResponse } from '@src/types/ems.response.dto';
-@Controller('/ems/patient')
+@Controller('/ems/patients')
 export class EmsPatientController {
   constructor(private readonly emsPatientService: EmsPatientService) {}
 

--- a/src/controllers/er/er.department.temporary.controller.ts
+++ b/src/controllers/er/er.department.temporary.controller.ts
@@ -1,0 +1,90 @@
+import { CurrentUser } from '@common/decorators/CurrentUser';
+import { createResponse } from '@common/interceptor/createResponse';
+import { ER_ERROR, isError, throwError } from '@config/errors';
+import { TypedBody, TypedException, TypedParam, TypedQuery, TypedRoute } from '@nestia/core';
+import { Controller, UseGuards } from '@nestjs/common';
+import { ErJwtAccessAuthGuard } from '@src/auth/guard/er.jwt.access.guard';
+import { ErAuth } from '@src/auth/interface';
+import { ErDepartmentService } from '@src/providers/er/er.department.service';
+import { ErDepartmentRequest, ErDepartmentResponse, TryCatch } from '@src/types';
+
+@Controller('/er')
+export class ErDepartmentTemporaryController {
+  constructor(private readonly erDepartmentService: ErDepartmentService) {}
+
+  /**
+   * 진료과 목록 조회 API
+   * 진료과 목록을 조회한다.
+   *
+   * 의사의 전문분야와 함께 조회한다.
+   * @author de-novo
+   * @tag er_department
+   * @summary 2023-10-30 - 진료과 목록 조회 API
+   */
+  @TypedRoute.Get('/departments')
+  async getDepartmentList() {
+    const result = await this.erDepartmentService.getDepartmentList();
+    return createResponse(result);
+  }
+
+  /**
+   * 진료과 조회 API
+   * 진료과를 조회한다.
+   *
+   * include 쿼리를 이용하여,
+   * 진료과가 활성화된 병원, 전문분야 등을 조회할수 있다.
+   * @author de-novo
+   * @tag er_department
+   * @summary 2023-10-30 - 진료과 조회 API
+   */
+  @TypedRoute.Get('/departments/:department_id')
+  async getDepartment() {
+    const result = await this.erDepartmentService.getDepartmentList();
+    return createResponse(result);
+  }
+  /**
+   * 병원 진료과 목록 조회 API
+   * 병원 진료과 목록을 조회한다.
+   *
+   * 응급실 ID를 이용하여, 병원의 진료과 목록을 조회한다.
+   *
+   * 첫조회시 해당 병원 진료과를 셋팅한다.
+   * @author de-novo
+   * @tag er_department
+   * @summary 2023-10-30 - 진료과 목록 조회 API
+   */
+  @TypedRoute.Get('/:er_id/departments')
+  @TypedException<ER_ERROR.ER_NOT_FOUND>(404, 'ER_NOT_FOUND')
+  async getDepartmentListByErId(
+    @TypedParam('er_id') er_id: string,
+    @TypedQuery() query: ErDepartmentRequest.GetDepartmentListQuery,
+  ): Promise<TryCatch<ErDepartmentResponse.GetDepartmentList, ER_ERROR.ER_NOT_FOUND>> {
+    const result = await this.erDepartmentService.getErDepartmentListByErIdWithQuery({ er_id, query });
+    if (isError(result)) return throwError(result);
+    return createResponse(result);
+  }
+
+  /**
+   * 병원 진료과 업데이트 API
+   *
+   * 병원의 진료과를 업데이트한다. (상태변경)
+   *
+   *
+   */
+  @TypedRoute.Patch('/:er_id/departments')
+  @UseGuards(ErJwtAccessAuthGuard)
+  async updateDepartmentListByErId(
+    @CurrentUser() user: ErAuth.AccessTokenSignPayload,
+    @TypedParam('er_id') er_id: string,
+    @TypedBody() body: ErDepartmentRequest.UpdateHospitalDepartmentDto,
+  ) {
+    const { update_departmet_list } = body;
+    const result = await this.erDepartmentService.updateHospitalDepartment({
+      user,
+      er_id,
+      update_departmet_list,
+    });
+    if (isError(result)) return throwError(result);
+    return createResponse(result);
+  }
+}

--- a/src/controllers/er/er.department.temporary.controller.ts
+++ b/src/controllers/er/er.department.temporary.controller.ts
@@ -20,6 +20,8 @@ export class ErDepartmentTemporaryController {
    * @author de-novo
    * @tag er_department
    * @summary 2023-10-30 - 진료과 목록 조회 API
+   *
+   * @returns 진료과 목록
    */
   @TypedRoute.Get('/departments')
   async getDepartmentList() {
@@ -36,6 +38,8 @@ export class ErDepartmentTemporaryController {
    * @author de-novo
    * @tag er_department
    * @summary 2023-10-30 - 진료과 조회 API
+   *
+   * @returns 진료과
    */
   @TypedRoute.Get('/departments/:department_id')
   @TypedException<ER_DEPARTMENT_ERROR.DEPARTMENT_NOT_EXIST>(404, 'ER_DEPARTMENT_ERROR.DEPARTMENT_NOT_EXIST')
@@ -61,6 +65,8 @@ export class ErDepartmentTemporaryController {
    * @author de-novo
    * @tag er_department
    * @summary 2023-10-30 - 진료과 목록 조회 API
+   *
+   * @returns 병원 진료과 목록
    */
   @TypedRoute.Get('/:er_id/departments')
   @TypedException<ER_ERROR.ER_NOT_FOUND>(404, 'ER_NOT_FOUND')
@@ -86,6 +92,9 @@ export class ErDepartmentTemporaryController {
    * @author de-novo
    * @tag er_department
    * @summary 2023-10-31 - 병원 진료과 업데이트 API
+   *
+   * @security access_token
+   * @returns 성공여부
    */
   @TypedRoute.Patch('/:er_id/departments')
   @TypedException<AUTH_ERROR.FORBIDDEN>(403, 'AUTH_ERROR.FORBIDDEN')

--- a/src/controllers/er/er.emergencyCenter.controller.ts
+++ b/src/controllers/er/er.emergencyCenter.controller.ts
@@ -4,7 +4,7 @@ import { Controller } from '@nestjs/common';
 import { ErEmergencyCenterService } from '@src/providers/er/er.emergencyCenter.service';
 import { ErEmergencyCenterRequest, ErEmergencyCenterResponse, Try } from '@src/types';
 
-@Controller('/er/emergency-center')
+@Controller('/er/emergency-centers')
 export class ErEmergencyCenterController {
   constructor(private readonly erEmergencyCenterService: ErEmergencyCenterService) {}
 

--- a/src/controllers/er/er.employee.controller.ts
+++ b/src/controllers/er/er.employee.controller.ts
@@ -173,4 +173,26 @@ export class ErEmployeeController {
     });
     return createResponse(result);
   }
+
+  /**
+   * 간호사 전문분야 조회 API
+   * 간호사 전문분야를 조회한다.
+   * - 간호사 전문분야는 ER에서만 사용한다.
+   *
+   * 직원[간호사] 생성시 사용한다.
+   *
+   * 의사 생성시에는 department조회를 통해 전문분야를 조회한다.
+   *
+   *
+   * @author de-novo
+   * @tag er_employee
+   * @summary 2023-10-31 - 간호사 전문분야 조회 API
+   *
+   * @returns 간호사 전문분야 리스트
+   */
+  @TypedRoute.Get('/specializations/nurse')
+  async getNurseSpecilizationList(): Promise<Try<ErEmployeeResponse.GetNurseSpecilizationList>> {
+    const result = await this.erEmployeeService.getNurseSpecialization();
+    return createResponse(result);
+  }
 }

--- a/src/controllers/er/er.employee.controller.ts
+++ b/src/controllers/er/er.employee.controller.ts
@@ -11,7 +11,7 @@ import { ErAuth } from '@src/auth/interface/er.auth.interface';
 import { ErEmployeeService } from '@src/providers/er/er.employee.service';
 import { ErEmployeeRequest, ErEmployeeResponse, Try, TryCatch } from '@src/types';
 
-@Controller('/er/employee')
+@Controller('/er/employees')
 export class ErEmployeeController {
   constructor(private readonly erEmployeeService: ErEmployeeService) {}
 

--- a/src/controllers/er/er.employee.controller.ts
+++ b/src/controllers/er/er.employee.controller.ts
@@ -43,6 +43,10 @@ export class ErEmployeeController {
     400,
     'ER_EMPLOYEE_ERROR.EMPLOYEE_MULTIPLE_ALREADY_EXIST_RETURN',
   )
+  @TypedException<ER_EMPLOYEE_ERROR.EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH>(
+    400,
+    'ER_EMPLOYEE_ERROR.EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH',
+  )
   @UseGuards(ErJwtAccessAuthGuard)
   async createManyEmployee(
     @TypedBody() body: ErEmployeeRequest.CreateManyDTO,

--- a/src/controllers/request/req.emsToEr.controller.ts
+++ b/src/controllers/request/req.emsToEr.controller.ts
@@ -14,7 +14,7 @@ import { ReqEmsToErService } from '@src/providers/req/req.emsToEr.service';
 import { ReqEmsToErRequest, Try, TryCatch } from '@src/types';
 import { ReqEmsToErResponse } from '@src/types/req.response.dto';
 
-@Controller('request/ems-to-er')
+@Controller('requests/ems-to-er')
 export class ReqEmsToErController {
   constructor(
     private readonly reqEmsToErService: ReqEmsToErService,

--- a/src/modules/er/department.module.ts
+++ b/src/modules/er/department.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ErDepartmentController } from '@src/controllers/er/er.department.controller';
+import { ErDepartmentTemporaryController } from '@src/controllers/er/er.department.temporary.controller';
 import { ErDepartmentService } from '@src/providers/er/er.department.service';
 
 @Module({
   providers: [ErDepartmentService],
-  controllers: [ErDepartmentController],
+  controllers: [ErDepartmentController, ErDepartmentTemporaryController],
 })
 export class ErDepartmentModule {}

--- a/src/providers/er/er.department.service.ts
+++ b/src/providers/er/er.department.service.ts
@@ -150,6 +150,39 @@ export class ErDepartmentService {
     });
     return departmentList;
   }
+  async getDepartmentByIdWithQuery({
+    department_id,
+    query,
+  }: {
+    department_id: number;
+    query: ErDepartmentRequest.GetDepartmetQuery;
+  }): Promise<ErDepartment.GetDepartment | ER_DEPARTMENT_ERROR.DEPARTMENT_NOT_EXIST> {
+    const { include = [] } = query;
+
+    const department = await this.prismaService.er_Department.findUnique({
+      where: {
+        department_id,
+      },
+      include: {
+        hospital_departments: include.includes('hospital')
+          ? {
+              include: {
+                hospital: true,
+              },
+              where: {
+                status: 'ACTIVE',
+              },
+            }
+          : undefined,
+        parent_department: include.includes('parent') ? true : undefined,
+        sub_departments: include.includes('sub') ? true : undefined,
+        doctor_specializations: include.includes('doctor_specializations') ? true : undefined,
+      },
+    });
+
+    if (!department) return typia.random<ER_DEPARTMENT_ERROR.DEPARTMENT_NOT_EXIST>();
+    return department;
+  }
 
   async getErDepartmentListByErIdWithQuery({
     er_id,

--- a/src/providers/er/er.employee.service.ts
+++ b/src/providers/er/er.employee.service.ts
@@ -257,4 +257,9 @@ export class ErEmployeeService {
 
     return { employee_list: employees, count: employee_count };
   }
+
+  async getNurseSpecialization() {
+    const nurseSpecializationList = await this.prismaService.er_NurseSpecialization.findMany();
+    return nurseSpecializationList;
+  }
 }

--- a/src/providers/er/er.employee.service.ts
+++ b/src/providers/er/er.employee.service.ts
@@ -1,9 +1,11 @@
 import { PrismaService } from '@common/prisma/prisma.service';
+import { excludeKeys } from '@common/util/excludeKeys';
 import { ER_EMPLOYEE_ERROR } from '@config/errors';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { AuthService } from '@src/auth/provider/common.auth.service';
 import typia from 'typia';
+import { v4 } from 'uuid';
 import { ErEmployee } from '../interface/er/er.employee.interface';
 
 Injectable();
@@ -15,7 +17,23 @@ export class ErEmployeeService {
     private readonly prismaService: PrismaService,
   ) {}
 
+  async createDtoValidation({ employees }: Pick<ErEmployee.CreateManyEmployee, 'employees'>) {
+    const errors = employees.filter((employee) => {
+      const { employee_doctor_specialization_list, employee_nurse_specialization_list, role } = employee;
+      return (
+        (!(role === 'NURSE') && employee_nurse_specialization_list) || // 간호사가 아닌데 간호사의 전문분야가 존재할 경우
+        (!(role === 'RESIDENT' || role === 'SPECIALIST') && employee_doctor_specialization_list) // 의사가 아닌데 의사의 전문분야가 존재할 경우
+      );
+    });
+    return errors;
+  }
+
   async createManyEmployee({ employees, user }: ErEmployee.CreateManyEmployee) {
+    const errors = await this.createDtoValidation({ employees });
+    if (errors.length > 0) {
+      return typia.random<ER_EMPLOYEE_ERROR.EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH>();
+    }
+
     this.logger.debug('createManyEmployee');
     const { hospital_id } = user;
     const existEmployeeIdCards = await this.checkManyEmployeeExist({
@@ -25,19 +43,108 @@ export class ErEmployeeService {
     if (existEmployeeIdCards.length > 0) {
       return typia.random<ER_EMPLOYEE_ERROR.EMPLOYEE_MULTIPLE_ALREADY_EXIST>();
     }
-    const employeeInfos = await Promise.all(
-      employees.map(async (employee) => {
-        const hashedPassword = await this.authService.hashPassword({ password: employee.password });
-        return {
-          hospital_id,
-          ...employee,
-          password: hashedPassword,
-        };
-      }),
+
+    const employeeInfoWithID = employees.map((employee) => {
+      return {
+        ...employee,
+        employee_id: v4(),
+      };
+    });
+
+    const hashedPasswords = await Promise.all(
+      employeeInfoWithID.map(async (employee) => this.authService.hashPassword({ password: employee.password })),
     );
-    const newEmployees = await this.prismaService.er_Employee.createMany({
+
+    const excludes: (keyof (typeof employeeInfoWithID)[0])[] = [
+      'employee_doctor_specialization_list',
+      'employee_nurse_specialization_list',
+      'password',
+    ];
+    const employeeInfos = employeeInfoWithID.map((employee) => {
+      const info = excludeKeys(employee, excludes);
+      return {
+        hospital_id,
+        ...info,
+        password: hashedPasswords.shift() || '', // 해싱된 패스워드 할당
+      };
+    });
+
+    const newEmployeeNurseSpecializationList = employeeInfoWithID.filter(
+      (employee) => employee.employee_nurse_specialization_list,
+    );
+    const newEmployeeDoctorSpecializationList = employeeInfoWithID.filter(
+      (employee) => employee.employee_doctor_specialization_list,
+    );
+    const newEmployeeNurseSpecialization = newEmployeeNurseSpecializationList.map((employee) => {
+      if (!employee.employee_nurse_specialization_list) return []; // never
+      return employee.employee_nurse_specialization_list.map((nurse_specialization_id) => {
+        return {
+          employee_id: employee.employee_id,
+          nurse_specialization_id,
+        };
+      });
+    });
+
+    const newEmployeeDoctorSpecialization = newEmployeeDoctorSpecializationList.map((employee) => {
+      if (!employee.employee_doctor_specialization_list) return []; // never
+      return employee.employee_doctor_specialization_list.map((doctor_specialization_id) => {
+        return {
+          employee_id: employee.employee_id,
+          doctor_specialization_id,
+        };
+      });
+    });
+    const nurseSpecializationFlat = newEmployeeNurseSpecialization.flat();
+    const doctorSpecializationFlat = newEmployeeDoctorSpecialization.flat();
+    const nurseSpecializationIdList = nurseSpecializationFlat.map((nurseSpecialization) => {
+      return nurseSpecialization.nurse_specialization_id;
+    });
+    const doctorSpecializationIdList = doctorSpecializationFlat.map((doctorSpecialization) => {
+      return doctorSpecialization.doctor_specialization_id;
+    });
+    const uniqueNurseSpecializationIdList = [...new Set(nurseSpecializationIdList)];
+    const uniqueDoctorSpecializationIdList = [...new Set(doctorSpecializationIdList)];
+    const existNurseSpecialization = uniqueNurseSpecializationIdList.length
+      ? await this.prismaService.er_NurseSpecialization.findMany({
+          where: {
+            nurse_specialization_id: {
+              in: uniqueNurseSpecializationIdList,
+            },
+          },
+        })
+      : [];
+    const existDoctorSpecialization = uniqueDoctorSpecializationIdList.length
+      ? await this.prismaService.er_DoctorSpecialization.findMany({
+          where: {
+            doctor_specialization_id: {
+              in: uniqueDoctorSpecializationIdList,
+            },
+          },
+        })
+      : [];
+
+    if (existNurseSpecialization.length !== uniqueNurseSpecializationIdList.length) {
+      return typia.random<ER_EMPLOYEE_ERROR.EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH>();
+    }
+    if (existDoctorSpecialization.length !== uniqueDoctorSpecializationIdList.length) {
+      return typia.random<ER_EMPLOYEE_ERROR.EMPLOYEE_ROLE_SPECIALIZATION_NOT_MATCH>();
+    }
+
+    const createEmployees = this.prismaService.er_Employee.createMany({
       data: employeeInfos,
     });
+    const createEmployeeNurseSpecialization = this.prismaService.er_EmployeeNurseSpecialization.createMany({
+      data: newEmployeeNurseSpecialization.flat(),
+    });
+    const createEmployeeDoctorSpecialization = this.prismaService.er_EmployeeDoctorSpecialization.createMany({
+      data: newEmployeeDoctorSpecialization.flat(),
+    });
+
+    const [newEmployees] = await this.prismaService.$transaction([
+      createEmployees,
+      createEmployeeNurseSpecialization,
+      createEmployeeDoctorSpecialization,
+    ]);
     return newEmployees;
   }
 
@@ -128,6 +235,19 @@ export class ErEmployeeService {
       },
       orderBy: {
         created_at: 'desc',
+      },
+      include: {
+        employee_doctor_specializations: {
+          include: {
+            doctor_specialization: true,
+          },
+        },
+        employee_nurse_specializations: {
+          include: {
+            nurse_specialization: true,
+          },
+        },
+        department: true,
       },
     };
     const employees: ErEmployee.GetEmpoyeeWithoutPassword[] = await this.prismaService.er_Employee.findMany(arg);

--- a/src/providers/interface/er/er.department.interface.ts
+++ b/src/providers/interface/er/er.department.interface.ts
@@ -1,5 +1,5 @@
 import { ER_DEPARTMENT_ERROR } from '@config/errors';
-import { er_Department } from '@prisma/client';
+import { Status, er_Department } from '@prisma/client';
 import { ErAuth } from '@src/auth/interface';
 import { ErDepartmentRequest, Extract_, HttpStatusKey } from '@src/types';
 
@@ -39,4 +39,24 @@ export namespace ErDepartment {
 
   export type GetDepartmentStatusListArg = { user: ErAuth.AccessTokenSignPayload };
   export type GetDepartmentStatusListReturn = GetFullDepartmentListReturn;
+
+  // 리팩토링 후
+  export type GetHospitalDepartmentList = {
+    department_id: number;
+    status: Status;
+    department: {
+      department_id: number;
+      department_name: string;
+      parent_department_id: number | null;
+    };
+  }[];
+
+  export type UpdateHospitalDepartmentDto = {
+    update_departmet_list: {
+      department_id: number;
+      status: Status;
+    }[];
+    user: ErAuth.AccessTokenSignPayload;
+    er_id: string;
+  };
 }

--- a/src/providers/interface/er/er.department.interface.ts
+++ b/src/providers/interface/er/er.department.interface.ts
@@ -1,5 +1,5 @@
 import { ER_DEPARTMENT_ERROR } from '@config/errors';
-import { Status, er_Department } from '@prisma/client';
+import { Status, er_Department, er_DoctorSpecialization, er_Hospital, er_HospitalDepartment } from '@prisma/client';
 import { ErAuth } from '@src/auth/interface';
 import { ErDepartmentRequest, Extract_, HttpStatusKey } from '@src/types';
 
@@ -50,6 +50,14 @@ export namespace ErDepartment {
       parent_department_id: number | null;
     };
   }[];
+  export type GetDepartment = er_Department & {
+    parent_department?: er_Department | null;
+    sub_departments?: er_Department[];
+    doctor_specializations?: er_DoctorSpecialization[];
+    hospital_departments?: (er_HospitalDepartment & {
+      hospital?: er_Hospital;
+    })[];
+  };
 
   export type UpdateHospitalDepartmentDto = {
     update_departmet_list: {

--- a/src/providers/interface/er/er.employee.interface.ts
+++ b/src/providers/interface/er/er.employee.interface.ts
@@ -1,4 +1,11 @@
-import { er_Employee } from '@prisma/client';
+import {
+  er_Department,
+  er_DoctorSpecialization,
+  er_Employee,
+  er_EmployeeDoctorSpecialization,
+  er_EmployeeNurseSpecialization,
+  er_NurseSpecialization,
+} from '@prisma/client';
 import { ErAuth } from '@src/auth/interface/er.auth.interface';
 import { ErEmployeeRequest } from '@src/types';
 
@@ -12,5 +19,13 @@ export namespace ErEmployee {
   export type GetEmployeeList = { query: ErEmployeeRequest.GetEmployeeListQuery } & {
     user: ErAuth.AccessTokenSignPayload;
   };
-  export type GetEmpoyeeWithoutPassword = Omit<er_Employee, 'password'>;
+  export type GetEmpoyeeWithoutPassword = Omit<er_Employee, 'password'> & {
+    employee_doctor_specializations?: (er_EmployeeDoctorSpecialization & {
+      doctor_specialization: er_DoctorSpecialization;
+    })[];
+    employee_nurse_specializations?: (er_EmployeeNurseSpecialization & {
+      nurse_specialization: er_NurseSpecialization;
+    })[];
+    department?: er_Department;
+  };
 }

--- a/src/types/er.request.dto.ts
+++ b/src/types/er.request.dto.ts
@@ -1,4 +1,5 @@
 import {
+  Status,
   er_Department,
   er_EmergencyRoomType,
   er_Employee,
@@ -233,6 +234,18 @@ export namespace ErDepartmentRequest {
     department_id: er_Department['department_id'];
     status: er_HospitalDepartment['status'];
   }[];
+
+  export type GetDepartmentListQuery = {
+    status?: Status[];
+  };
+
+  export type UpdateHospitalDepartmentDto = {
+    update_departmet_list: {
+      department_id: number;
+      status: Status;
+    }[] &
+      tags.MinItems<1>;
+  };
 }
 
 export namespace ErEquipmentRequest {

--- a/src/types/er.request.dto.ts
+++ b/src/types/er.request.dto.ts
@@ -246,6 +246,10 @@ export namespace ErDepartmentRequest {
     }[] &
       tags.MinItems<1>;
   };
+
+  export type GetDepartmetQuery = {
+    include?: ('hospital' | 'doctor_specializations' | 'parent' | 'sub')[];
+  };
 }
 
 export namespace ErEquipmentRequest {

--- a/src/types/er.request.dto.ts
+++ b/src/types/er.request.dto.ts
@@ -241,7 +241,19 @@ export namespace ErDepartmentRequest {
 
   export type UpdateHospitalDepartmentDto = {
     update_departmet_list: {
+      /**
+       * 변경할 진료과 id
+       * @type number
+       * @title 진료과 id
+       * @description 직원의 진료과 id
+       */
       department_id: number;
+      /**
+       * 변경할 진료과 상태
+       * @type string
+       * @title 진료과 상태
+       * @description 진료과 상태
+       */
       status: Status;
     }[] &
       tags.MinItems<1>;

--- a/src/types/er.request.dto.ts
+++ b/src/types/er.request.dto.ts
@@ -57,11 +57,37 @@ export namespace ErEmployeeRequest {
     password: string;
 
     /**
-     * 직원의 ROLE - ADMIN, DOCTOR, NURSE, EMT
+     * 직원의 ROLE - ADMIN(관리자), SPECIALIST(전문의), RESIDENT(전공의), NURSE(간호사), EMT(응급구조사)
      * @title 직원의 역할
      * @type er_EmployeeRole
      */
     role: er_EmployeeRole;
+
+    /**
+     * 진료과 id
+     * null 일 경우, 직원의 진료과를 지정하지 않는다.
+     * @type number
+     * @title 진료과 id
+     * @description 직원의 진료과 id
+     */
+    department_id?: number;
+
+    /**
+     * 의사의 전문분야 id list
+     * null 일 경우, 직원의 전문분야를 지정하지 않는다.
+     * @type string[]
+     * @title 의사의 전문분야 id list - 의사일경우에만 사용
+     */
+    employee_doctor_specialization_list?: string[];
+
+    /**
+     * 간호사의 전문분야 id list
+     * null 일 경우, 직원의 전문분야를 지정하지 않는다.
+     * @type string[]
+     * @title 간호사의 전문분야 id list - 간호사일경우에만 사용
+     * @description 간호사의 전문분야 id list
+     */
+    employee_nurse_specialization_list?: string[];
   }
 
   export interface CreateManyDTO {

--- a/src/types/er.response.dto.ts
+++ b/src/types/er.response.dto.ts
@@ -43,6 +43,7 @@ export namespace ErDepartmentResponse {
   export type UpdateAvailableDepartment = ErDepartment.UpdateAvailableDepartmentReturn;
   export type GetDepartmentStatusListDto = ErDepartment.GetDepartmentStatusListReturn;
   export type GetDepartmentList = ErDepartment.GetHospitalDepartmentList;
+  export type GetDepartment = ErDepartment.GetDepartment;
 }
 
 export namespace ErEquipmentResponse {

--- a/src/types/er.response.dto.ts
+++ b/src/types/er.response.dto.ts
@@ -1,6 +1,7 @@
 import { er_Employee } from '@prisma/client';
 import { ErDepartment } from '@src/providers/interface/er/er.department.interface';
 import { ErEmergencyCenter } from '@src/providers/interface/er/er.emergencyCenter.interface';
+import { ErEmployee } from '@src/providers/interface/er/er.employee.interface';
 import { ErEquipment } from '@src/providers/interface/er/er.equipment.interface';
 import { ErIllness } from '@src/providers/interface/er/er.illness.interface';
 import { DateToString } from '.';
@@ -25,7 +26,9 @@ export namespace ErEmployeeResponse {
   export interface CheckManyEmployeeExist {
     exists: Pick<er_Employee, 'id_card'>[];
   }
-  export type GetEmployeeList = { count: number } & { employee_list: Omit<er_Employee, 'password'>[] };
+  export type GetEmployeeList = { count: number } & {
+    employee_list: ErEmployee.GetEmpoyeeWithoutPassword[];
+  };
 
   export interface UpdatePassword {
     update_success: boolean;

--- a/src/types/er.response.dto.ts
+++ b/src/types/er.response.dto.ts
@@ -42,6 +42,7 @@ export namespace ErEmergencyCenterResponse {
 export namespace ErDepartmentResponse {
   export type UpdateAvailableDepartment = ErDepartment.UpdateAvailableDepartmentReturn;
   export type GetDepartmentStatusListDto = ErDepartment.GetDepartmentStatusListReturn;
+  export type GetDepartmentList = ErDepartment.GetHospitalDepartmentList;
 }
 
 export namespace ErEquipmentResponse {

--- a/src/types/er.response.dto.ts
+++ b/src/types/er.response.dto.ts
@@ -1,4 +1,4 @@
-import { er_Employee } from '@prisma/client';
+import { er_Employee, er_NurseSpecialization } from '@prisma/client';
 import { ErDepartment } from '@src/providers/interface/er/er.department.interface';
 import { ErEmergencyCenter } from '@src/providers/interface/er/er.emergencyCenter.interface';
 import { ErEmployee } from '@src/providers/interface/er/er.employee.interface';
@@ -33,6 +33,7 @@ export namespace ErEmployeeResponse {
   export interface UpdatePassword {
     update_success: boolean;
   }
+  export type GetNurseSpecilizationList = er_NurseSpecialization[];
 }
 
 export namespace ErEmergencyCenterResponse {


### PR DESCRIPTION
# 변경내용

url 리소스 단수형 -> 복수형 으로 변경했습니다.

## er employee  #24  
- doctor -> resident, specialist 
- 간호사 및 의사 전문분야 추가

:GET /api/er/employees/specializations/nurse
- 간호사의 전문분야를 조회하는 api입니다
- 의사 전문분야는 아래 departments 조회 api를 이용합니다.
- -> 고민중인것 : 현재 restful 하지않은것같음 

## departement
이전 API는 제거하지 않았습니다.

:GET /api/er/department 
- 현재 서비스에 존재하는 진료과를 반환합니다.
- 추가적으로 해당과와 연관되어있는 전문분야(세부분야)를 포함합니다


:GET /api/er/departments/:department_id
- 진료과 id를 이용하여 진료과를 조회합니다.
- query의 include를 이용하여 진료과와 연관되어있는 정보를 함께 조회할 수 있습니다.
- -> 부모진료과, 자식진료과, 진료가능한병원, 관련있는 의사전문분야 를 조회할수있습니다.


:GET /api/er/:er_id/departments
- 병원의 진료과 목록을 조회합니다.
- 응급실 id를 이용하여 해당 응급실의 진료과를 조회할수 있습니다.
- query의 status를 이용하여 해당하는 status의 진료과를 조회 할 수 있습니다
- 해당병원의 첫 조회시, 기본 진료과 정보를 database에 setting합니다
- (프론트에서 상태 변경 API를 사용 하기 위해선 무조건 조회가 필요함, 따라서 첫조회때 만들어도 문제는 없음)
- 
-> 고민중인 것: dbInit을 통하여 모든병원의 진료과를 초기에 설정할까 고민중입니다.


:PATCH /api/er/:er_id/departments
- 해당병원의 진료과 상태를 변경합니다.
- 상위 진료과가 INACTIVE가 될 경우, 하위 진료과 모두 INACTIVE로 변합니다.
- 상위 진료과가 ACTIVE로 수정 할 경우, 하위 진료과 모두 ACTIVE로 변합니다
- 상위 진료과가 INACTIVE인 상태에서, 하위 진료과를 ACTIVE할 경우 상위 진료과도 ACTIVE로 변합니다.


